### PR TITLE
Add err declaration in SetDefaultPrinter

### DIFF
--- a/out.go
+++ b/out.go
@@ -23,6 +23,7 @@ func IsvalidDevMode(dev *DevMode, buf uint16) (b bool) {
 
 func SetDefaultPrinter(printerName string) (b bool) {
 	var p0 *uint16
+	var err error
 	p0, err = syscall.UTF16PtrFromString(printerName)
 	if err != nil {
 		return


### PR DESCRIPTION
The usage of GetDefaultPrinterName() returns `out.go:26:6: undefined: err` during build as the err is undeclared in the SetDefaultPrinter method @jadefox10200 